### PR TITLE
fix: change UsersService import as providers to UsersModule as imports

### DIFF
--- a/contabil-backend/src/account/account.module.ts
+++ b/contabil-backend/src/account/account.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AccountService } from './account.service';
 import { AccountController } from './account.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [AccountController],
-  providers: [AccountService, UsersService],
+  providers: [AccountService],
 })
 export class AccountModule {}

--- a/contabil-backend/src/entry/entry.module.ts
+++ b/contabil-backend/src/entry/entry.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { EntryService } from './entry.service';
 import { EntryController } from './entry.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [EntryController],
   providers: [EntryService],
 })

--- a/contabil-backend/src/partner/partner.module.ts
+++ b/contabil-backend/src/partner/partner.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PartnerService } from './partner.service';
 import { PartnerController } from './partner.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [PartnerController],
-  providers: [PartnerService, UsersService],
+  providers: [PartnerService],
 })
 export class PartnerModule {}

--- a/contabil-backend/src/resources/resources.module.ts
+++ b/contabil-backend/src/resources/resources.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ResourcesService } from './resources.service';
 import { ResourcesController } from './resources.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [ResourcesController],
-  providers: [ResourcesService, UsersService],
+  providers: [ResourcesService],
 })
 export class ResourcesModule {}

--- a/contabil-backend/src/roles/roles.module.ts
+++ b/contabil-backend/src/roles/roles.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { RolesService } from './roles.service';
 import { RolesController } from './roles.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [RolesController],
-  providers: [RolesService, UsersService],
+  providers: [RolesService],
 })
 export class RolesModule {}

--- a/contabil-backend/src/type-entry/type-entry.module.ts
+++ b/contabil-backend/src/type-entry/type-entry.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeEntryService } from './type-entry.service';
 import { TypeEntryController } from './type-entry.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [TypeEntryController],
-  providers: [TypeEntryService, UsersService],
+  providers: [TypeEntryService],
 })
 export class TypeEntryModule {}

--- a/contabil-backend/src/type-movement/type-movement.module.ts
+++ b/contabil-backend/src/type-movement/type-movement.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeMovementService } from './type-movement.service';
 import { TypeMovementController } from './type-movement.controller';
-import { UsersService } from 'src/users/users.service';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   controllers: [TypeMovementController],
-  providers: [TypeMovementService, UsersService],
+  providers: [TypeMovementService],
 })
 export class TypeMovementModule {}


### PR DESCRIPTION
Closes #25 #26

## 📑 Description
All modules were using `UsersService` as a "providers", but a better way is to directly use the `UsersModule` as "imports" instead. And the `entry.module.ts` was missing the `UsersService/UsersModule`, so the app was constantly crashing.

## ℹ Additional Information
Using `UsersService` as a "providers" doesn't crash the app but is less reliable.