### PR TITLE
fix: type error when rendering role in user details modal

### DIFF
--- a/contabil-frontend/src/pages/users/VisualizarUsers.tsx
+++ b/contabil-frontend/src/pages/users/VisualizarUsers.tsx
@@ -304,7 +304,7 @@ const VisualizarUsers: React.FC = () => {
             <DetailField
               label="Função"
               icon={<Shield className="w-4 h-4" />}
-              value={<span className="px-3 py-1 rounded-full text-sm font-medium">{detailsModal.data.role?.name || detailsModal.data.role}</span>}
+              value={<span className="px-3 py-1 rounded-full text-sm font-medium">{detailsModal.data.role?.name || 'Não definido'}</span>}
             />
             <DetailField
               label="Status"


### PR DESCRIPTION
## 📑 Description
Corrige erro de TypeScript que impedia o build do frontend no Docker.

## ℹ Additional Information
O código tentava renderizar um objeto `RoleResponse` diretamente como fallback no JSX:
`{detailsModal.data.role?.name || detailsModal.data.role}`